### PR TITLE
fix: Add explicit instruction for Claude to post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -149,11 +149,19 @@ jobs:
           # General review guidance is in --append-system-prompt (applies to ALL event types)
           prompt: |
             ${{ github.event_name == 'pull_request' && format('
+            REPO: {1}
+            PR NUMBER: {2}
+
             Review this pull request.
 
             START by running: git diff origin/{0}...HEAD --name-status
             Then examine the changed lines using: git diff origin/{0}...HEAD
-            ', github.base_ref) || '' }}
+
+            IMPORTANT: You MUST post your review as a GitHub PR comment using:
+            gh pr comment {2} --body "YOUR_REVIEW_HERE"
+
+            Do NOT just output text - you must use the gh command to post your review to the PR.
+            ', github.base_ref, github.repository, github.event.pull_request.number) || '' }}
 
           # CLI arguments (v1 format)
           # --append-system-prompt provides base Alliance instructions for ALL event types
@@ -186,6 +194,8 @@ jobs:
             IMPORTANT: Many PRs are small fixes. If the changes look correct, simply say Changes look good.
 
             Keep reviews concise and actionable. Reference specific line numbers from the diff.
+
+            CRITICAL: You MUST post your review to the PR using gh pr comment. Do not just output text.
 
             IMPORTANT: Always end your responses with developer usage instructions:
 


### PR DESCRIPTION
## Summary

The v1 migration broke PR comment posting because Claude was not explicitly instructed to use `gh pr comment` to post reviews.

## Problem

After the v1 migration, Claude would:
1. Run the review successfully
2. Analyze the code
3. Output review text to the workflow log
4. **Never post anything to the PR**

This was because the prompt didn't tell Claude to actually post a comment.

## Fix

- Add `REPO` and `PR NUMBER` context to the prompt
- Add explicit instruction: `You MUST post your review as a GitHub PR comment using gh pr comment`
- Add reminder in system prompt: `CRITICAL: You MUST post your review to the PR using gh pr comment`

## Testing

After this fix, repos using the shared workflow should have Claude post comments again:
- agr_ui
- agr_literature_ui  
- agr_java_software
- agr_automated_information_extraction

## Note

Repos with custom workflows (agr_literature_service, agr_curation, agr_curation_api_client) may need separate fixes if they have the same issue.