### PR TITLE
KANBAN-1067: Use CLAUDE_PR_REVIEW_MODEL org variable for model selection

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       model:
-        description: 'Claude model to use'
+        description: 'Claude model to use. If empty, falls back to CLAUDE_PR_REVIEW_MODEL org/repo variable.'
         required: false
-        default: 'claude-sonnet-4-5-20250929'
+        default: ''
         type: string
       max_turns:
         description: 'Maximum conversation turns'
@@ -166,7 +166,7 @@ jobs:
           # CLI arguments (v1 format)
           # --append-system-prompt provides base Alliance instructions for ALL event types
           claude_args: |
-            --model ${{ inputs.model }}
+            --model ${{ inputs.model || vars.CLAUDE_PR_REVIEW_MODEL }}
             --max-turns ${{ inputs.max_turns }}
             --allowedTools "Bash,Edit,Read,Write,Glob,Grep,LS"
             --append-system-prompt "You are assisting with an Alliance of Genome Resources application.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ jobs:
   claude-review:
     uses: alliance-genome/.github/.github/workflows/claude-code-review.yml@main
     with:
-      model: claude-sonnet-4-20250514
       use_zen_tools: true
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -45,11 +44,13 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+> **Note:** The model defaults to the `CLAUDE_PR_REVIEW_MODEL` GitHub org/repo variable (e.g., `claude-sonnet-4-6`). To override, pass `model:` explicitly.
+
 ### Configuration Options
 
 | Input | Description | Default | Required |
 |-------|-------------|---------|----------|
-| `model` | Claude model to use | `claude-sonnet-4-20250514` | No |
+| `model` | Claude model to use. If empty, falls back to `CLAUDE_PR_REVIEW_MODEL` org/repo variable. | `''` (empty) | No |
 | `max_turns` | Maximum conversation turns | `10` | No |
 | `review_focus` | What to focus reviews on | `critical bugs and database performance` | No |
 | `trigger_phrase` | Phrase for manual reviews | `@claude` | No |
@@ -68,13 +69,13 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
-#### Custom Configuration
+#### Custom Configuration (with explicit model override)
 ```yaml
 jobs:
   claude-review:
     uses: alliance-genome/.github/.github/workflows/claude-code-review.yml@main
     with:
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6  # Override the org variable
       max_turns: "5"
       review_focus: "security vulnerabilities and performance"
       trigger_phrase: "@ai-review"


### PR DESCRIPTION
## Summary
- Changes reusable workflow model input default to empty string
- Falls back to `CLAUDE_PR_REVIEW_MODEL` org/repo variable when no model is explicitly passed
- Updates README to document the variable-based approach
- Callers that pass `model:` explicitly still get their specified model

## Auto-fixes these repos (no PRs needed)
Repos that call the reusable workflow without passing `model:` will automatically pick up the org variable:
- agr_ui
- agr_java_software
- agr_automated_information_extraction
- agr_literature_ui

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Open test PR on a repo that uses the reusable workflow
- [ ] Confirm Claude reviewer uses claude-sonnet-4-6