### PR TITLE
Fix silent drops: provide explicit prompt for issue_comment events

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -180,9 +180,12 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: ${{ inputs.trigger_phrase }}
 
-          # PR-specific prompt with git diff instructions (only for automated PR reviews)
-          # For manual @claude triggers, the user's comment is the instruction
-          # General review guidance is in --append-system-prompt (applies to ALL event types)
+          # Event-specific prompt:
+          # - pull_request: Full review with diff instructions
+          # - issue_comment: Read user's comment and respond (with PR number so Claude
+          #   doesn't have to guess). Without this, the action sends NO user message
+          #   in agent mode, causing intermittent "silent drops" where Claude just
+          #   outputs a generic greeting and exits.
           prompt: |
             ${{ github.event_name == 'pull_request' && format('
             REPO: {1}
@@ -198,6 +201,22 @@ jobs:
 
             Do NOT just output text - you must use the gh command to post your review to the PR.
             ', github.base_ref, github.repository, github.event.pull_request.number) || '' }}
+            ${{ github.event_name == 'issue_comment' && format('
+            REPO: {0}
+            PR NUMBER: {1}
+
+            A user has commented on this PR requesting your assistance.
+
+            START by reading their comment: gh pr view {1} --comments --json comments --jq ".comments[-1].body"
+            Then check the PR diff: git diff origin/main...HEAD
+
+            If they are asking for a review or check, perform a full code review of the changes.
+
+            IMPORTANT: You MUST post your response as a GitHub PR comment using:
+            gh pr comment {1} --body "YOUR_RESPONSE_HERE"
+
+            Do NOT just output text - you must use the gh command to post your response to the PR.
+            ', github.repository, github.event.issue.number) || '' }}
 
           # CLI arguments (v1 format)
           # --append-system-prompt provides base Alliance instructions for ALL event types


### PR DESCRIPTION
## Summary

**Root cause of the "silent drop" bug found and fixed.**

When a user comments `@claude` on a PR, the `prompt:` field evaluates to empty string (the `format()` expression only fires for `pull_request` events). In agent mode with an empty prompt, Claude receives NO user message — only the system prompt. Claude's behavior is then stochastic:

- **Sometimes**: Claude proactively runs `gh pr list` and does a full review (success)
- **Sometimes**: Claude outputs "Ready to assist with the AGR repository" and exits (silent drop)

### Evidence from execution transcript analysis

| | Failed Run (silent drop) | Successful Run |
|---|---|---|
| **input_tokens** | 2 | 2 |
| **Turns** | 1 | 9 |
| **Tool calls** | **0** | 8 (all Bash) |
| **Duration** | 10s | 237s |
| **Cost** | $0.06 | $0.69 |
| **Output** | "Ready to assist..." | Full review posted |
| **Claude's thinking** | "The user hasn't provided a specific request yet" | "The user seems to have triggered a PR review" |

Both runs had **identical** `system.init`, token counts, agent mode, and cached context. The only difference was Claude's stochastic interpretation.

### Fix

Add an explicit `prompt` block for `issue_comment` events that provides:
- The repository name and PR number
- Instructions to read the user's comment (`gh pr view` with jq)
- Instructions to check the diff
- Explicit `gh pr comment` posting requirement

This ensures Claude always receives a clear user message with actionable instructions, eliminating the stochastic failure mode.

## Test plan

- [ ] Comment `@claude review` on a test PR — should consistently post a review
- [ ] Verify `issue_comment` runs now show >1 turns and tool calls in diagnostics
- [ ] Verify auto-retry is no longer needed (silent drops should stop)
- [ ] Verify `pull_request` event reviews still work as before