### PR TITLE
Simplify silent drop handling: notification with retry instructions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,8 +55,8 @@ jobs:
       issues: write
       # REQUIRED: Claude Code Action uses OIDC for GitHub authentication
       id-token: write
-      # Required for Claude to read CI results on PRs AND for auto-retry via gh run rerun
-      actions: write
+      # Required for Claude to read CI results on PRs
+      actions: read
     if: |
       github.actor != 'pjhale' &&
       github.actor != 'claude[bot]' && (
@@ -331,9 +331,9 @@ jobs:
 
             const baselineCount = parseInt('${{ steps.pre_check.outputs.baseline_count }}');
             const reviewOutcome = '${{ steps.claude_review.outcome }}';
-            const maxRetries = parseInt('${{ inputs.max_retries }}') || 3;
             const notifyUsers = '${{ inputs.notify_on_failure }}'.split(',').map(u => u.trim()).filter(Boolean);
             const mentionStr = notifyUsers.length > 0 ? '\n\ncc ' + notifyUsers.map(u => `@${u}`).join(' ') : '';
+            const triggerPhrase = '${{ inputs.trigger_phrase }}';
 
             // Count current claude[bot] comments
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -351,101 +351,50 @@ jobs:
               return;
             }
 
-            // --- No new comment was posted ---
+            // --- No new comment was posted (silent drop or timeout) ---
+            // Automatic retry is not possible from within the same workflow run:
+            // - gh run rerun fails with "This workflow is already running"
+            // - GITHUB_TOKEN comments don't trigger new workflow runs (anti-loop)
+            // So we post a notification with retry instructions for the user.
 
-            // Use github.run_attempt to track retries instead of counting PR comments.
-            // run_attempt starts at 1 for the first run, increments with each rerun.
-            const runAttempt = parseInt('${{ github.run_attempt }}') || 1;
-            const retriesUsed = runAttempt - 1;
-            console.log(`Run attempt: ${runAttempt}, Retries used: ${retriesUsed}/${maxRetries}`);
-
-            // Handle timeout — don't auto-retry (PR is likely too complex, would timeout again)
             if (reviewOutcome === 'cancelled') {
-              const body = [
-                '**Review Timed Out**',
-                '',
-                'The Claude Code review exceeded the 8-minute timeout and was cancelled.',
-                'This usually means the review was unusually complex or encountered an issue.',
-                '',
-                'Please try again — if this keeps happening, contact the repository maintainers.',
-                '',
-                `[View execution logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) | [Download transcript](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts)`,
-                '',
-                '---',
-                `*Automated fallback from the Claude Code Review workflow.*${mentionStr}`
-              ].join('\n');
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body: body
-              });
-              core.setFailed('Claude Code Review timed out — no auto-retry for timeouts');
-              return;
-            }
-
-            // Handle silent drop — auto-retry via gh run rerun if under limit.
-            // Previous approach posted @claude comments to trigger issue_comment events,
-            // but GITHUB_TOKEN events don't create new workflow runs (GitHub anti-loop
-            // protection). Using the rerun API bypasses this entirely.
-            if (retriesUsed < maxRetries) {
-              const attemptNum = retriesUsed + 1;
-              console.log(`Triggering auto-retry via run rerun (attempt ${attemptNum}/${maxRetries})`);
-
-              // Post a notification comment so PR participants know what's happening
+              // Timeout — likely too complex, would timeout again
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
                 body: [
-                  `**Claude Code Review auto-retry (attempt ${attemptNum}/${maxRetries})**`,
+                  '**Claude Code Review — Timed Out**',
                   '',
-                  'Previous review completed but did not post a comment. Re-running automatically.',
+                  'The review exceeded the 8-minute timeout.',
                   '',
-                  `[View previous run logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) | [Download transcript](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts)${mentionStr}`
+                  `**To retry**, comment: \`${triggerPhrase} please review my changes\``,
+                  '',
+                  `[View run logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) | [Download transcript](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts)`,
+                  '',
+                  '---',
+                  `*Automated notification from the Claude Code Review workflow.*${mentionStr}`
                 ].join('\n')
               });
-
-              // Trigger a rerun of this workflow run. This preserves the original
-              // event context (PR number, base ref, head SHA) and increments
-              // github.run_attempt, which we use to track retry count.
-              // Requires actions: write in both the reusable workflow AND the caller.
-              try {
-                await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun', {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: context.runId
-                });
-                core.setFailed(`Claude Code Review silent drop — rerun triggered (attempt ${attemptNum}/${maxRetries})`);
-              } catch (rerunError) {
-                // If rerun fails (e.g. caller hasn't granted actions: write yet),
-                // log the error but don't crash — the notification comment was already posted.
-                console.log(`Rerun API failed: ${rerunError.message}`);
-                console.log('The caller workflow may need actions: write permission.');
-                core.setFailed(`Claude Code Review silent drop — rerun failed: ${rerunError.message}`);
-              }
+              core.setFailed('Claude Code Review timed out');
             } else {
-              // Max retries exceeded — post final fallback
-              const body = [
-                '**Review Failed After Multiple Attempts**',
-                '',
-                `Claude completed ${maxRetries + 1} review attempt(s) but did not post a comment each time.`,
-                'This is a known intermittent issue being investigated upstream.',
-                '',
-                'A human review is needed for this PR.',
-                '',
-                `[View latest run logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) | [Download transcript](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts)`,
-                '',
-                '---',
-                `*Automated fallback from the Claude Code Review workflow.*${mentionStr}`
-              ].join('\n');
-
+              // Silent drop — Claude completed but didn't post a comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                body: body
+                body: [
+                  '**Claude Code Review — Review Not Posted**',
+                  '',
+                  'Claude completed but did not post a review comment (known intermittent issue).',
+                  '',
+                  `**To retry**, comment: \`${triggerPhrase} please review my changes\``,
+                  '',
+                  `[View run logs](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) | [Download transcript](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts)`,
+                  '',
+                  '---',
+                  `*Automated notification from the Claude Code Review workflow.*${mentionStr}`
+                ].join('\n')
               });
-              core.setFailed(`Claude Code Review failed after ${maxRetries} auto-retry attempts`);
+              core.setFailed('Claude Code Review silent drop — notification posted');
             }


### PR DESCRIPTION
## Summary

The `gh run rerun` approach from PR #7 doesn't work — you can't rerun a workflow from within itself (API returns "This workflow is already running"). `GITHUB_TOKEN` comments also can't trigger new runs (anti-loop protection).

This PR simplifies to a **notification comment with retry instructions**:
- On silent drop: posts comment telling user to `@claude please review my changes`
- On timeout: same pattern
- Manual retry via `@claude` now works reliably (fixed in PR #6)

Also reverts `actions: write` back to `actions: read`.

## Changes
- Remove rerun API call, run_attempt tracking, max_retries logic
- Replace with simple notification comments for both timeout and silent drop cases
- Revert `actions: write` → `actions: read`
- Net -83 lines / +32 lines (simpler is better)

## Test plan
- [ ] Merge this PR
- [ ] Open a test PR to trigger Claude review
- [ ] If silent drop occurs, verify notification comment appears with retry instructions
- [ ] Comment `@claude please review my changes` and verify the retry works